### PR TITLE
fix(ingest): push 用 GITHUB_TOKEN + manifest ASCII 键

### DIFF
--- a/.github/UPLOAD_README.md
+++ b/.github/UPLOAD_README.md
@@ -45,26 +45,29 @@ TUNING 凛空小猫
 
 ## manifest.toml（可选，建议提供专辑名）
 
-```toml
-album = "永昼花"            # 目标专辑名（缺省时由 LLM 从歌词本推断，PR 标注待确认）
+⚠️ 这是**标准 TOML**，键名用 **ASCII**（与 `res/<专辑>/meta.toml` 的中文键不同——那是项目自定义格式，
+不是合法 TOML）。显式给出的字段**覆盖**自动抽取的 meta。
 
-# 以下均可选，显式给出则**覆盖**自动抽取的 meta：
-发行日期 = "2026-01-31"     # 也可用 year=
-出品     = ["Zeno"]
-演唱     = ["星尘", "海伊", "诗岸"]
-作词     = []
-作曲     = []
-编曲     = []
-调校     = []
-曲绘     = ["Aries苑"]
-混音     = []
-发布     = "[Bilibili](https://www.bilibili.com/video/...)"
-购买     = "[淘宝](...)"
-电子     = "随专辑附赠"
+```toml
+album = "永昼花"                  # 目标专辑名（缺省时由 LLM 从歌词本推断，PR 标注待确认）
+
+year        = "2026-01-31"        # 发行日期
+produce     = ["Zeno"]            # 出品
+vocal       = ["星尘", "海伊", "诗岸"]  # 演唱（只填虚拟歌姬/声库）
+lyricist    = []                  # 作词
+composer    = []                  # 作曲
+arranger    = []                  # 编曲
+tuning      = []                  # 调校
+illustrator = ["Aries苑"]         # 曲绘
+mixer       = []                  # 混音
+lyric_maker = []                  # 歌词制作
+release     = "[Bilibili](https://www.bilibili.com/video/...)"  # 发布
+purchase    = ""                  # 购买
+electronic  = ""                  # 电子
 ```
 
-> 字段名同 `res/<专辑>/meta.toml`（中文键）。未提供的字段由流水线从歌词本/Staff 抽取，
-> 仍为空则留空，等人工在 PR 里补。
+> 未提供的字段由流水线从歌词本/Staff 自动抽取，仍为空则留空，等人工在 PR 里补。
+> 值是人名列表/文本即可；键名见上（ASCII 内部名）。
 
 ## 提示
 

--- a/.github/scripts/ingest/organize.py
+++ b/.github/scripts/ingest/organize.py
@@ -65,11 +65,22 @@ ORGANIZE_SYSTEM = """你是音乐专辑歌词整理专家。给你一份专辑�
 3.去掉人名 @用户名 后缀 4.tracks 按歌词本顺序编号。"""
 
 
+# 中文/别名键 → internal（manifest 容错：若用户写了 quoted 中文键也能识别）
+_KEY_ALIAS = dict(_META.get("mapping", {}))
+
+
+def _normalize_manifest(m: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for k, v in (m or {}).items():
+        out[_KEY_ALIAS.get(k, k)] = v
+    return out
+
+
 def _read_toml(path: Path) -> dict[str, Any]:
     if not path.is_file() or tomllib is None:
         return {}
     try:
-        return tomllib.loads(path.read_text(encoding="utf-8"))
+        return _normalize_manifest(tomllib.loads(path.read_text(encoding="utf-8")))
     except Exception as e:  # noqa: BLE001
         print(f"⚠️  manifest 解析失败 {path}: {e}", file=sys.stderr)
         return {}

--- a/.github/upload_manifest.example.toml
+++ b/.github/upload_manifest.example.toml
@@ -1,17 +1,19 @@
-# upload 投递清单示例 — 复制为 manifest.toml 放进投递目录根
-# 所有字段可选；显式给出的会覆盖流水线自动抽取的 meta。字段名同 res/<专辑>/meta.toml。
+# upload 投递清单示例 — 复制为 manifest.toml 放进投递目录根。
+# 注意：这是**标准 TOML**，键名用 ASCII（与 res/<专辑>/meta.toml 的中文键不同——
+# 那是项目自定义格式）。所有字段可选；显式给出的会覆盖流水线自动抽取的 meta。
 
-album = "永昼花"                 # 目标专辑名（强烈建议提供）
+album = "永昼花"                  # 目标专辑名（强烈建议提供）
 
-发行日期 = ""                    # 也可写 year = "2026-01-31"
-出品 = []
-演唱 = ["星尘", "海伊", "诗岸"]   # 只填虚拟歌姬/声库
-作词 = []
-作曲 = []
-编曲 = []
-调校 = []
-曲绘 = ["Aries苑"]
-混音 = []
-发布 = ""                        # 如 "[Bilibili](https://www.bilibili.com/video/...)"
-购买 = ""
-电子 = ""
+year        = ""                  # 发行日期，如 "2026-01-31"
+produce     = []                  # 出品
+vocal       = ["星尘", "海伊", "诗岸"]  # 演唱（只填虚拟歌姬/声库）
+lyricist    = []                  # 作词
+composer    = []                  # 作曲
+arranger    = []                  # 编曲
+tuning      = []                  # 调校
+illustrator = ["Aries苑"]         # 曲绘
+mixer       = []                  # 混音
+lyric_maker = []                  # 歌词制作
+release     = ""                  # 发布，如 "[Bilibili](https://www.bilibili.com/video/...)"
+purchase    = ""                  # 购买
+electronic  = ""                  # 电子

--- a/.github/workflows/upload_ingest.yml
+++ b/.github/workflows/upload_ingest.yml
@@ -124,6 +124,7 @@ jobs:
         if: steps.run.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.PULL_TOKEN }}
+          PUSH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -134,8 +135,9 @@ jobs:
           git checkout -b "$BRANCH"
           git add res
           git commit -m "ingest: ${{ steps.run.outputs.album }} (via upload by @${{ github.actor }})"
-          # 用 PULL_TOKEN 推送 → PR 能触发 lrc_auto_audit
-          git push "https://x-access-token:${GH_TOKEN}@github.com/${GH_REPO}.git" "$BRANCH"
+          # 分支用 GITHUB_TOKEN 推送（有 contents:write；PULL_TOKEN 是细粒度 PAT 无推送权）。
+          # PR 仍由下方 gh(PULL_TOKEN=PAT) 创建 → 才能触发 lrc_auto_audit。
+          git push "https://x-access-token:${PUSH_TOKEN}@github.com/${GH_REPO}.git" "$BRANCH"
           BODY=$(cat <<EOF
           ### 🤖 自动摄取投稿
 


### PR DESCRIPTION
实弹暴露两 bug 修复：1) PULL_TOKEN(细粒度 PAT)无 contents:write→分支改用 GITHUB_TOKEN 推，PR 仍 PULL_TOKEN 开(触发 audit)；2) manifest 须标准 TOML(ASCII 键)，中文裸键 tomllib 解析失败→改文档+organize 加中文键容错。