### PR TITLE
fix(ingest): extraheader 推送权 + meta 名称字段去重

### DIFF
--- a/.github/scripts/ingest/organize.py
+++ b/.github/scripts/ingest/organize.py
@@ -155,14 +155,28 @@ def _fmt_toml_value(value: Any, is_list: bool) -> str:
     return f'"{value}"'
 
 
+_NAME_INTERNALS = {k for k, _ in NAME_FIELDS}
+
+
 def render_meta_toml(meta: dict[str, Any], names: dict[str, str]) -> str:
+    """生成 meta.toml。名称字段(前缀/中文名/英文名/后缀)取自 names；其余取自 meta。
+
+    注意：真实 config.toml 的 field_schema **已包含**名称字段，DEFAULT_CONFIG 没有。
+    若 schema 已含名称字段，就在循环里用 names 值输出（避免与特判重复）；
+    否则在「出品」后补一组（兼容 DEFAULT_CONFIG）。
+    """
     lines: list[str] = []
+    schema_has_names = any(f["internal"] in _NAME_INTERNALS for f in FIELD_SCHEMA)
     emitted_names = False
     for f in FIELD_SCHEMA:
         internal, toml_key = f["internal"], f["toml_key"]
+        if internal in _NAME_INTERNALS:
+            lines.append(f'{toml_key} = "{names.get(internal, "")}"')
+            emitted_names = True
+            continue
         is_list = f["type"] == "list"
         lines.append(f"{toml_key} = {_fmt_toml_value(meta.get(internal, [] if is_list else ''), is_list)}")
-        if internal == "produce" and not emitted_names:
+        if internal == "produce" and not schema_has_names and not emitted_names:
             for key, label in NAME_FIELDS:
                 lines.append(f'{label} = "{names.get(key, "")}"')
             emitted_names = True

--- a/.github/workflows/upload_ingest.yml
+++ b/.github/workflows/upload_ingest.yml
@@ -47,7 +47,8 @@ jobs:
           ref: main
           fetch-depth: 0
           path: repo
-          token: ${{ secrets.PULL_TOKEN }}
+          # 用默认 GITHUB_TOKEN：其注入的 http.extraheader 有 contents:write，
+          # 可推分支。（若用 PULL_TOKEN，它的 extraheader 会覆盖 URL token 且无推送权 → 403）
 
       - name: Reset upload dropbox (keep only workflow + README)
         env:
@@ -124,7 +125,6 @@ jobs:
         if: steps.run.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.PULL_TOKEN }}
-          PUSH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -135,9 +135,9 @@ jobs:
           git checkout -b "$BRANCH"
           git add res
           git commit -m "ingest: ${{ steps.run.outputs.album }} (via upload by @${{ github.actor }})"
-          # 分支用 GITHUB_TOKEN 推送（有 contents:write；PULL_TOKEN 是细粒度 PAT 无推送权）。
-          # PR 仍由下方 gh(PULL_TOKEN=PAT) 创建 → 才能触发 lrc_auto_audit。
-          git push "https://x-access-token:${PUSH_TOKEN}@github.com/${GH_REPO}.git" "$BRANCH"
+          # 推 origin：repo 由默认 GITHUB_TOKEN checkout，其 extraheader 有 contents:write。
+          # PR 由下方 gh(GH_TOKEN=PULL_TOKEN=PAT) 创建 → 才能触发 lrc_auto_audit。
+          git push origin "$BRANCH"
           BODY=$(cat <<EOF
           ### 🤖 自动摄取投稿
 


### PR DESCRIPTION
实弹 v3 全绿后发现：1) Checkout main 用 PULL_TOKEN 注入的 http.extraheader 覆盖 URL token→403，改默认 GITHUB_TOKEN+git push origin；2) 真实 config.toml field_schema 已含名称字段，render_meta_toml 特判致重复，已改。