### PR TITLE
fix(ci): approve esbuild & parcel-watcher build scripts to fix catalog deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,11 @@
     "markdown-it": "^14.1.0",
     "vue-scriptx": "^0.2.7",
     "vuepress-plugin-alert": "0.0.5"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@parcel/watcher",
+      "esbuild"
+    ]
   }
 }


### PR DESCRIPTION
## Problem

The **Generate Catalog and Album Packs** workflow has been failing on every run (e.g. runs at 18:48 / 18:50 / 18:58 UTC on 2026-06-09). The `optimize` job succeeds, but the `deploy` job fails at the **Install dependencies** step:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @parcel/watcher@2.5.6, esbuild@0.21.5, esbuild@0.24.2
##[error]Process completed with exit code 1.
```

## Cause

`deploy.yml` uses `pnpm/action-setup@v4` with `version: latest` (pnpm 10). pnpm 10 does not execute dependency build scripts unless they are explicitly approved, and in this environment the ignored builds cause a non-zero exit, aborting `pnpm install --no-frozen-lockfile`. `esbuild` in particular needs its postinstall to fetch its platform binary, which `@vuepress/bundler-vite` relies on for `pnpm run docs:build`.

## Fix

Declare the two packages in `pnpm.onlyBuiltDependencies` in `package.json` (the canonical output of `pnpm approve-builds`). This approves their build scripts, runs the required postinstall, and clears the install failure — restoring the Cloudflare Pages deploy.

## Notes

- Scope is limited to `package.json`; no dependency versions or workflow logic changed.
- Opened as a **draft** for maintainer review before merge.
