### PR TITLE
fix(upload): inst 弹窗标记后继续上传;manifest 非法 TOML 静默失效;pdf/docx 归类歌词文档

### DIFF
--- a/.github/scripts/ingest/organize.py
+++ b/.github/scripts/ingest/organize.py
@@ -247,10 +247,33 @@ def llm_order_tracks(audio_names: list[str], album_hint: str = "") -> list[dict]
         if not _is_inst_filename(file_name):
             continue
         t["inst"] = True
-        stem = Path(file_name).stem
-        m = re.match(r"^\d+[\s._-]+(.*)", stem)
-        t["title"] = (m.group(1) if m else stem).strip().strip("。.")
+        t["title"] = _title_from_filename(file_name)
     return valid
+
+
+def _title_from_filename(file_name: str) -> str:
+    """文件名 → 保留标记的曲名（去掉开头曲序号，inst/伴奏 等标记原样保留）。"""
+    stem = Path(file_name).stem
+    m = re.match(r"^\d+[\s._-]+(.*)", stem)
+    return (m.group(1) if m else stem).strip().strip("。.")
+
+
+def apply_inst_overrides(tracks: list[dict], inst_marked: set, inst_as_song: set) -> None:
+    """工作站显式标记（manifest 伴奏/原曲 键）覆盖文件名 inst 启发式，原地改。
+
+    伴奏：强制 inst=True（用户在上传弹窗确认了这是伴奏轨）；
+    原曲：摘掉 inst 标记（文件名启发式误伤，按正曲转写对齐）。
+    在 llm_order_tracks 之后调用——优先级：显式标记 > 文件名正则 > LLM。
+    """
+    for t in tracks:
+        name = Path(str(t.get("file") or "")).name
+        if name in inst_marked and not t.get("inst"):
+            t["inst"] = True
+            t["title"] = _title_from_filename(name)
+            print(f"  ○ 显式标记为伴奏: {name}", file=sys.stderr)
+        elif name in inst_as_song and t.get("inst"):
+            t["inst"] = False
+            print(f"  ◉ 显式标记为原曲（推翻文件名启发式）: {name}", file=sys.stderr)
 
 
 ASSIGN_SYSTEM = """你是音乐专辑歌词整理专家。给你专辑的权威轨单（来自音频文件，顺序与曲名

--- a/.github/scripts/ingest/pipeline.py
+++ b/.github/scripts/ingest/pipeline.py
@@ -11,6 +11,7 @@
     音频(.wav/.flac/...)   → faster-whisper 词级时间戳 → audio_words
     封面图（主视图/cover/最大图）→ cover.*
     manifest.toml          → 专辑名 + meta 覆盖 + [链接] 歌词拍照→音轨绑定
+                             + 伴奏/原曲 显式标记（覆盖文件名 inst 启发式）
                                           ↓
                               ingest.organize → res/<专辑>/
 
@@ -148,6 +149,21 @@ def extract_photo_links(manifest: dict) -> dict[str, str]:
     return out
 
 
+def extract_inst_overrides(manifest: dict) -> tuple[set, set]:
+    """弹出 manifest 的 伴奏/原曲 显式标记（工作站 inst 弹窗的选择）→ basename 集合。
+
+    伴奏：强制按伴奏/无人声轨处理（不转写，复用同名正曲时间轴或写纯音乐占位）；
+    原曲：推翻文件名启发式的误伤，按正曲转写对齐。pop 掉避免混进 meta 合并链。
+    """
+    out: list[set] = []
+    for key in ("伴奏", "原曲"):
+        v = manifest.pop(key, None)
+        names = ({Path(str(x)).name for x in v if str(x).strip()}
+                 if isinstance(v, list) else set())
+        out.append(names)
+    return out[0], out[1]
+
+
 def extract_album_pages(manifest: dict) -> set:
     """manifest album_pages（SP 分配的专辑级元信息照片名）→ basename 集合。
 
@@ -237,6 +253,15 @@ def _process_album(album: str, src: Path, res_dir: Path, work: Path, dry_run: bo
             tracks_explicit.append(parsed)
             print(f"  歌词轨: {p.name} → {parsed['title']} ({len(parsed['lines'])} 行)", file=sys.stderr)
 
+    # manifest 提前读：伴奏/原曲 显式标记须在轨单编排（第 3 步）生效，SP 页分流
+    # （第 2 步）也用它；meta 覆盖仍在第 5 步与音频 tag 合并
+    manifest_path = src / "manifest.toml"
+    manifest = org_mod._read_toml(manifest_path) if manifest_path.is_file() else {}
+    photo_links = extract_photo_links(manifest)
+    if photo_links:
+        print(f"  🔗 manifest 携带 {len(photo_links)} 条歌词拍照绑定", file=sys.stderr)
+    inst_marked, inst_as_song = extract_inst_overrides(manifest)
+
     # 2) 图片 OCR + 文档抽取 → 逐页歌词本文本（保留页出处，供绑定/置信度匹配；
     #    拼接版供纯文本分轨与抽 credits）
     pages: list[dict] = []
@@ -257,8 +282,7 @@ def _process_album(album: str, src: Path, res_dir: Path, work: Path, dry_run: bo
     # SP 专辑级元信息页（manifest album_pages）：仅无图的文本页需分流到 credits；
     # 有图时 vision 直接看到 SP 页并抽 meta，无需分流
     if pages:
-        _mpath = src / "manifest.toml"
-        album_pages = extract_album_pages(org_mod._read_toml(_mpath)) if _mpath.is_file() else set()
+        album_pages = extract_album_pages(manifest)
         if album_pages:
             sp_pages = [pg for pg in pages if pg["name"] in album_pages]
             if sp_pages:
@@ -281,6 +305,7 @@ def _process_album(album: str, src: Path, res_dir: Path, work: Path, dry_run: bo
     inst_files: set[str] = set()
     if buckets["audio"]:
         tracks_plan = org_mod.llm_order_tracks([p.name for p in buckets["audio"]], album)
+        org_mod.apply_inst_overrides(tracks_plan, inst_marked, inst_as_song)
         keep = {t.get("file") for t in tracks_plan}
         inst_files = {t.get("file") for t in tracks_plan if t.get("inst")}
         skipped = [p.name for p in buckets["audio"] if p.name not in keep]
@@ -325,11 +350,6 @@ def _process_album(album: str, src: Path, res_dir: Path, work: Path, dry_run: bo
 
     # 5) 整理 + 对齐 → res/<专辑>/（meta 全自动；专辑名 = 文件夹名 album）
     #    可选：若投递目录恰含 manifest.toml 则作为 meta 覆盖（非必需，不鼓励）。
-    manifest_path = src / "manifest.toml"
-    manifest = org_mod._read_toml(manifest_path) if manifest_path.is_file() else {}
-    photo_links = extract_photo_links(manifest)
-    if photo_links:
-        print(f"  🔗 manifest 携带 {len(photo_links)} 条歌词拍照绑定", file=sys.stderr)
     # 音频 tag 权威元信息：优先级仅次于 manifest（manifest 显式键覆盖 tag）
     tag_meta, source_hint = extract_audio_meta(buckets["audio"])
     manifest = {**tag_meta, **manifest}

--- a/docs/.vuepress/components/UploadBox.vue
+++ b/docs/.vuepress/components/UploadBox.vue
@@ -541,8 +541,9 @@ function guessRole(p) {
 }
 
 // 疑似伴奏/无人声轨：曲名里的 inst/ins/off vocal/伴奏/无人声（分隔符包裹，避免
-// 误伤 "Inspire" 这类词内含 ins 的正常曲名）。命中不阻止提交，只在提交前问一句
-// ——投稿者常把伴奏也扔进音频文件夹，混进曲单会被当正曲对齐入库
+// 误伤 "Inspire" 这类词内含 ins 的正常曲名）。命中不阻止提交，只在提交前问一次：
+// 两个选择都继续上传——确定=按原曲（转写对齐），取消=自动标记为伴奏（管道不转写，
+// 复用同名正曲时间轴或写「纯音乐」占位）。选择经 manifest 伴奏/原曲 键传给管道
 const INST_RE = /(?:^|[\s._()[\]-])(?:inst(?:rumental)?|ins|off[\s_-]?vocal)(?:[\s._()[\]-]|$)/i;
 const isLikelyInst = (relPath) => {
   const stem = baseName(relPath).replace(/\.[^.]+$/, '');
@@ -721,12 +722,20 @@ async function onDrop(e) {
 
 // 辅助信息 → manifest.toml（organize.py 原生消费：album + 发布/购买中文键，
 // 值与主项目 meta 相同的 [标签](url) 格式；manifest 在 meta 合并链优先级最高。
-// [链接] 表 = 歌词拍照→音轨绑定，管道按 basename 归一消费）
+// [链接] 表 = 歌词拍照→音轨绑定；伴奏/原曲 = inst 弹窗的选择——均按 basename 消费）
 function syncManifest(name) {
   const bili = linkBili.value.trim();
   const dizzy = linkDizzy.value.trim();
   const links = [];
   const albumPages = [];
+  // inst 弹窗的选择固化进 manifest：标记伴奏 → 管道强制按伴奏处理；
+  // 确认原曲 → 推翻管道侧同一套文件名启发式的强制 inst
+  const instMarked = [];
+  const instAsSong = [];
+  for (const i of items.value) {
+    if (i.role !== 'song' || !i.instConfirmed) continue;
+    (i.instMarked ? instMarked : instAsSong).push(baseName(i.relPath));
+  }
   for (const p of items.value) {
     if (p.role !== 'photo' || !p.linkTo) continue;
     if (p.linkTo === 'SP') { albumPages.push(baseName(p.relPath)); continue; }
@@ -734,21 +743,29 @@ function syncManifest(name) {
     if (s) links.push([p.relPath, baseName(s.relPath)]);
   }
   const prev = items.value.findIndex((i) => i.relPath === 'manifest.toml' && i.auto);
-  if (!bili && !dizzy && !links.length && !albumPages.length) {
+  if (!bili && !dizzy && !links.length && !albumPages.length
+      && !instMarked.length && !instAsSong.length) {
     if (prev !== -1) items.value.splice(prev, 1);
     return;
   }
   const esc = (s) => s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
   const wrap = (label, v) => /^https?:\/\//.test(v) ? `[${label}](${v})` : v;
   const lines = [`album = "${esc(name)}"`];
-  if (bili) lines.push(`发布 = "${esc(wrap('Bilibili', bili))}"`);
-  if (dizzy) lines.push(`购买 = "${esc(wrap('dizzylab', dizzy))}"`);
+  // 中文键必须加引号：TOML 裸键仅限 ASCII，裸中文键会让 tomllib 整文件解析失败
+  if (bili) lines.push(`"发布" = "${esc(wrap('Bilibili', bili))}"`);
+  if (dizzy) lines.push(`"购买" = "${esc(wrap('dizzylab', dizzy))}"`);
   // SP 专辑级元信息照片：管道当 credits 抽 meta，不分配歌词
   if (albumPages.length) {
     lines.push(`album_pages = [${albumPages.map((n) => `"${esc(n)}"`).join(', ')}]`);
   }
+  if (instMarked.length) {
+    lines.push(`"伴奏" = [${instMarked.map((n) => `"${esc(n)}"`).join(', ')}]`);
+  }
+  if (instAsSong.length) {
+    lines.push(`"原曲" = [${instAsSong.map((n) => `"${esc(n)}"`).join(', ')}]`);
+  }
   if (links.length) {
-    lines.push('', '[链接]');
+    lines.push('', '["链接"]');
     for (const [img, audio] of links) lines.push(`"${esc(img)}" = "${esc(audio)}"`);
   }
   const file = new File([lines.join('\n') + '\n'], 'manifest.toml', { type: 'application/toml' });
@@ -801,8 +818,11 @@ async function run() {
     i.role === 'song' && !i.instConfirmed && isLikelyInst(i.relPath));
   if (instSuspects.length) {
     const list = instSuspects.map((i) => baseName(i.relPath)).join('、');
-    if (!window.confirm(`以下音频疑似伴奏/无人声轨，不像是完整原曲：\n${list}\n\n确定按原曲一并上传吗？`)) return;
-    instSuspects.forEach((i) => { i.instConfirmed = true; });
+    const asSong = window.confirm(
+      `以下音频疑似伴奏/无人声轨：\n${list}\n\n`
+      + '「确定」= 按原曲上传（转写对齐出完整歌词）；\n'
+      + '「取消」= 自动标记为伴奏并继续上传（不转写，复用同名正曲时间轴，无则写「纯音乐」占位）。');
+    instSuspects.forEach((i) => { i.instConfirmed = true; i.instMarked = !asSong; });
   }
   syncManifest(name);
   saveDraft();

--- a/docs/.vuepress/components/UploadBox.vue
+++ b/docs/.vuepress/components/UploadBox.vue
@@ -119,7 +119,7 @@
       </div>
       <p class="ub-total" :class="{ err: oversize > 0 }">{{ totalText }}</p>
       <p class="ub-dim small">
-        支持歌词文本 / 歌词本图片或 PDF / 音频 / Staff 表 / 封面；单文件上限 95MB。
+        支持歌词文本或 PDF/DOCX 歌词册 / 歌词本图片 / 音频 / Staff 表 / 封面；单文件上限 95MB。
         点击文件名可重命名路径；右侧下拉修改用途会自动归类到对应目录；
         列表按类型分区，区内按文件名开头编号排序。点击图片可放大预览并翻转方向。
         歌词拍照可在下方关联到指定曲目、拖拽调整顺序。上传期间请勿关闭本页。
@@ -533,7 +533,8 @@ function guessRole(p) {
   if (/\.(png|jpe?g|webp|gif|bmp|tiff?)$/.test(base)) {
     return /(cover|封面|主视图)/.test(base) ? 'cover' : 'photo';
   }
-  if (/\.(pdf|docx?)$/.test(base)) return 'photo';
+  // pdf/docx 是歌词文档（管道走文档抽取，整册消费），不是拍照——不进照片关联面板
+  if (/\.(pdf|docx?)$/.test(base)) return 'text';
   if (/\.(txt|lrc|md)$/.test(base)) {
     return /(staff|制作|名单)/.test(base) ? 'staff' : 'text';
   }

--- a/docs/.vuepress/components/uploadDraft.js
+++ b/docs/.vuepress/components/uploadDraft.js
@@ -21,6 +21,7 @@ export function serializeDraft(album, items, at = Date.now(), submittedRef = '')
       linkTo: i.linkTo || 0,
       porder: i.porder == null ? null : i.porder,
       instConfirmed: !!i.instConfirmed,
+      instMarked: !!i.instMarked,
     })),
   };
 }
@@ -60,6 +61,7 @@ export function restoreItem(item, saved) {
   item.linkTo = saved.linkTo || 0;
   if (saved.porder != null) item.porder = saved.porder;
   if (saved.instConfirmed) item.instConfirmed = true;
+  if (saved.instMarked) item.instMarked = true;
   if (saved.rotation) item.rotation = saved.rotation;
   return { restored: true, rotated: !!saved.rotation };
 }


### PR DESCRIPTION
## 问题一:inst 弹窗死循环(本次报障)

旧逻辑:疑似伴奏弹窗点「取消」直接中止整次提交且**不记录任何状态**,下次点提交又原样再问——除非违心点「确定」,否则永远出不去。

现在两个选择都继续上传:

- **确定** = 按原曲上传(转写对齐出完整歌词);
- **取消** = 自动标记为伴奏并继续上传(管道不转写,复用同名正曲时间轴,无则写「纯音乐,请欣赏」占位)。

选择按文件持久化(`instConfirmed`/`instMarked`,含 localStorage 草稿),不再重复询问;并固化进 manifest 的 `"伴奏"`/`"原曲"` 两个列表键。管道在 `llm_order_tracks` 之后应用显式覆盖(`organize.apply_inst_overrides`):`伴奏` 强制 `inst=True`,`原曲` 摘掉文件名启发式的误伤——优先级:显式标记 > 文件名正则 > LLM。

## 问题二:manifest 裸中文键 = 非法 TOML,整文件静默丢失(顺带发现的存量 bug)

工作站生成的 `发布 = ...`、`购买 = ...`、`[链接]` 是**裸中文键,TOML 规范不允许**(裸键仅限 ASCII):`tomllib` 直接整文件解析失败,`_read_toml` 吞掉异常返回 `{}`——**只要投稿填了发布/购买链接或做了歌词拍照绑定,整个 manifest(含绑定关系)一直在被静默丢弃**。已改为全部带引号(`"发布"`、`"购买"`、`["链接"]`,新增键同样),`organize` 的别名映射本就按字符串匹配,带引号键解析结果一致。

## 问题三:pdf/docx 误归「拍照」

`guessRole` 原把 `.pdf/.docx` 归为 `photo`,会混进照片关联面板——但文档无法预览/旋转/逐页绑定,管道也是整册抽取消费。改归 `text`(歌词本·文本),进「歌词」分组,不再出现在绑定网格;UI 提示文案同步。

## 变更

- `UploadBox.vue`:弹窗改双向继续;`syncManifest` 产出 `"伴奏"`/`"原曲"` 列表并修复中文键引号;pdf/docx 归 `text`;
- `uploadDraft.js`:草稿持久化/恢复 `instMarked`;
- `pipeline.py`:manifest 提前读(轨单编排前),新增 `extract_inst_overrides`(pop 键,避免混入 meta 合并链),SP 页分流复用同一次读取;
- `organize.py`:新增 `apply_inst_overrides` + 抽出 `_title_from_filename` 公共逻辑。

## 验证

- 模拟前端全量 manifest 由 `tomllib` 解析 → `extract_photo_links` / `extract_inst_overrides` / `extract_album_pages` 消费链逐项断言;覆盖应用与幂等性断言;回归确认旧版裸中文键确实整文件失效;
- VuePress 全站构建通过(两次,含 pdf/docx 归类改动)。